### PR TITLE
Chapter4 - search 퍼포먼스 향상 목적으로 index 추가

### DIFF
--- a/db/migrate/20170108065025_add_trgm_index_to_customers.rb
+++ b/db/migrate/20170108065025_add_trgm_index_to_customers.rb
@@ -1,0 +1,7 @@
+class AddTrgmIndexToCustomers < ActiveRecord::Migration[5.0]
+  def change
+    enable_extension 'pg_trgm'
+    add_index :customers, [:first_name, :last_name, :email], name: 'trgm_keyword_search_index',
+              using: :gin, order: {first_name: :gin_trgm_ops, last_name: :gin_trgm_ops, email: :gin_trgm_ops}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170103095737) do
+ActiveRecord::Schema.define(version: 20170108065025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "customers", force: :cascade do |t|
     t.string   "first_name", null: false
@@ -22,6 +23,7 @@ ActiveRecord::Schema.define(version: 20170103095737) do
     t.string   "username",   null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index "first_name gin_trgm_ops, last_name gin_trgm_ops, email gin_trgm_ops", name: "trgm_keyword_search_index", using: :gin
     t.index ["email"], name: "index_customers_on_email", unique: true, using: :btree
     t.index ["username"], name: "index_customers_on_username", unique: true, using: :btree
   end


### PR DESCRIPTION
## Regular Index vs Trigram Index
regular index, 즉 [btree index는 search에 도움이 안된다](https://niallburkley.com/blog/index-columns-for-like-in-postgres/#regular-index). index를 무시하고 full table scan에 들어가기 때문이다. 이 때문에 trigram index를 사용한다. trigram index는 string을 작게 쪼개서 index한다. 이렇게 작게 쪼개진 index는 [`LIKE`나 `ILIKE`쿼리를 돌리는데 뛰어난 퍼포먼스를 보여준다](https://niallburkley.com/blog/index-columns-for-like-in-postgres/#enter-postgres-pgtrgm).

## Trigram Index
Trigram Index는 Full text search 에 특화되었다. 이 index는 GIN(Generalized Inverted Index)과 GiST(Generalized Search Tree)로 나뉘어진다. 단 search 작업에 index는 필수는 아니다. 하지만 검색이 빈번하게 있다면 매우 도움이 된다.
### [GIN and GiST](https://www.postgresql.org/docs/9.4/static/textsearch-indexes.html)
 * GIN indexes are three types faster to search, but they take more time to index. They also take more disk space. Use it when you have more than 100K unique terms.
 * GiST indexes are slower than GIN indexes, but they’re faster to update. Use it when you have up to 100K unique terms.

정적인 자료라면 GIN이 유리하고 동적인 자료라면 GiST가 유리하다. 여기서는 정적인 search 용도이므로 GIN을 사용한다. 

### GIN 적용하기 - SQL
GIN은 기본적으로 array용이라서 그냥 사용하면 에러가 뜬다. 이 때문에 [gin_trgm_ops](https://hashrocket.com/blog/posts/exploring-postgres-gin-index#what-is-gin_trgm_ops-)라는 옵션을 사용 해야한다. 이 옵션을 사용하면 psql은 컬럼에 대해서 trigram을 적용한다. 적용된 쿼리는 아래와 같다.

```sql
CREATE INDEX users_search_idx ON users USING gin (first_name gin_trgm_ops, last_name gin_trgm_ops);
```

### GIN 적용하기 - Active Record
AR에서는 코드가 어떻게 짜일까? 다소 특이하게도 AR에서 index를 [operator class와 함께 사용할 때는 order를 사용한다](http://apidock.com/rails/v4.2.1/ActiveRecord/ConnectionAdapters/SchemaStatements/add_index#1553-Adding-index-with-other-operator-classes-PostgreSQL-). 어째서 그러한지는 연구가 필요하다. 아래는 order로 `gin_trgm_ops`를 사용한 코드다.

```ruby
add_index :users, [:first_name, :last_name], name: 'users_search_idx', using: :gin, order: {first_name: :gin_trgm_ops, last_name: :gin_trgm_ops}
```

## [pg_trgm](https://www.postgresql.org/docs/current/static/pgtrgm.html)
Trigram Index 을 그냥 사용하면 안될 거다. pg_trgm이라는 extension을 활성화 시켜야하기 때문이다. 이 extension을 활성화 시키는 코드는 아래와 같다.

```sql
CREATE EXTENSION IF NOT EXISTS pg_trgm
```

```ruby
enable_extension 'pg_trgm'
```

하지만 이 역시도 그냥은 안되는데, extension을 추가하려면 Superuser 권한이 필요하기 때문이다. 결국은 Superuser
권한을 부여해야하는데, 권한을 남발하기 영 찝찝했다. 찾아보니 [whitelist](https://github.com/dimitri/pgextwlist) 라는 extension이 있었다. 특정 role이 특정 extension 을 설치하는 권한을 줄 수 있도록 하는 extension이다. 하지만 맥에서는 설치가 힘들어 보여서 포기하고, local에서는 superuser를 부여하고, prod에서 whitelist에 포함시키는 것으로 결정했다. 참고로 [heroku에는 whitelist 기능이 기본적으로 탑재되었다](http://stackoverflow.com/a/20745157/3910390).

## 결론은?
미치도록 빨라졌다. 평균 6ms에서 0.2ms로 줄었다.

---
 * [LIKE에 index 적용하기 - 성능 측정 자료가 함께 첨부되었다](https://niallburkley.com/blog/index-columns-for-like-in-postgres/)
 * [GIN index 적용하기 - gin_trgm_ops 힌트를 얻었다](https://hashrocket.com/blog/posts/exploring-postgres-gin-index#what-is-gin_trgm_ops-)
 * [test search 빠르게 하기 SO 문서 - limit에 대한 글 같은데 읽다맘](http://stackoverflow.com/a/11250001/3910390)
* [GIN과 GiST 공식 psql 문서](https://www.postgresql.org/docs/9.4/static/textsearch-indexes.html)
* [AR에서 gin index 추가하기 SO 문서 - 스트링에서 그냥 쓰면 에러가 난다는 것을 알았다](http://stackoverflow.com/a/18728384/3910390)
 * [AR에서 gin index 추가할 때 gin_trgm_ops 쓰는 SO 문서](http://stackoverflow.com/a/29658928/3910390)
* [Trigram의 원리가 적힌 글](https://www.sitepoint.com/awesome-autocomplete-trigram-search-in-rails-and-postgresql/)
 * [pg_trgm 공식 psql 문서](https://www.postgresql.org/docs/current/static/pgtrgm.html)
 * [왜 Superuser만 CREATE EXTENSION을 할 수 있는지 SO 문서](http://stackoverflow.com/questions/20723100/why-can-only-a-superuser-create-extension-hstore-but-not-on-heroku/20745157)
 * [pgexwlist github](https://github.com/dimitri/pgextwlist)